### PR TITLE
Add CI workflow for Python linting and React build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI - Python Lint and React Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+
+    - name: Run flake8
+      run: |
+        flake8 autoeda --ignore=E501
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+
+    - name: Install npm dependencies
+      run: npm install
+      working-directory: frontend  
+
+    - name: Run React build
+      run: npm run build
+      working-directory: frontend


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automate:

- Python linting using flake8
- React frontend build verification

The workflow is triggered on push and pull requests to the main branch.  
It helps maintain code quality and ensures the React build doesn't break.
